### PR TITLE
DRY up the calls to get Community so it can be easily swapped

### DIFF
--- a/src/community.ts
+++ b/src/community.ts
@@ -1,0 +1,5 @@
+import {Community} from 'tupelo-wasm-sdk'
+
+export const getCommunity = async ()=> {
+    return Community.getDefault()
+}

--- a/src/explorer.tsx
+++ b/src/explorer.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Community, ChainTree } from 'tupelo-wasm-sdk';
+import { ChainTree } from 'tupelo-wasm-sdk';
 import { Typography, makeStyles, Theme } from '@material-ui/core';
 import {Link} from 'react-navi'
 import NodeDisplay from './nodedisplay';
 import { route } from 'navi'
+import { getCommunity } from './community';
 
 
 export const explorerRoute = route(async (req) => {
@@ -44,7 +45,7 @@ export const fetchTree = async (did: string):Promise<IFetchTreeResult> => {
             found: false,
         }
     }
-    const community = await Community.getDefault()
+    const community = await getCommunity()
 
     try {
         const tip = await community.getTip(did)

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,5 +1,6 @@
 import { createStore } from 'react-hooks-global-state';
-import {EcdsaKey, ChainTree, Community} from 'tupelo-wasm-sdk';
+import {EcdsaKey, ChainTree} from 'tupelo-wasm-sdk';
+import { getCommunity } from './community';
 
 let resolve:Function
 export const globalStorageStarted = new Promise((res)=> {resolve = res})
@@ -61,7 +62,7 @@ async function setStoredState() {
         resolve()
         throw new Error("had a userKey but no user Tree")
     }
-    let community = await Community.getDefault()
+    let community = await getCommunity()
     let tip = await community.getTip(userTreeDid)
 
     let tree = new ChainTree({

--- a/src/wallet/establishtokendialog.tsx
+++ b/src/wallet/establishtokendialog.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react'
 import {  Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, TextField, CircularProgress, Button } from '@material-ui/core';
-import { ChainTree, Community, establishTokenTransaction } from 'tupelo-wasm-sdk'
+import { ChainTree, establishTokenTransaction } from 'tupelo-wasm-sdk'
+import { getCommunity } from '../community';
 
 /**
  * Establishing a token allows you to mint them. It is done before a mint because it allows you to set a monetary
@@ -18,7 +19,7 @@ export const EstablishTokenDialog = ({open, onClose, tree}:{open:boolean, onClos
             throw new Error("userTree is undefined")
         }
         setLoading(true)
-        const community = await Community.getDefault()
+        const community = await getCommunity()
         await community.playTransactions(tree, [establishTokenTransaction(tokenName, maxAmount)])
         _onClose()
     }

--- a/src/wallet/login.tsx
+++ b/src/wallet/login.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { route,mount } from 'navi';
 import { TextField, Button, Grid, Typography, CircularProgress } from '@material-ui/core';
-import { EcdsaKey, Tupelo, Community, ChainTree, setOwnershipTransaction, setDataTransaction } from 'tupelo-wasm-sdk';
+import { EcdsaKey, Tupelo, ChainTree, setOwnershipTransaction, setDataTransaction } from 'tupelo-wasm-sdk';
 import { useNavigation } from 'react-navi';
 import { dispatch } from '../state';
+import { getCommunity } from '../community';
 
 export const usernameKey = "/_crazywallet/username"
 const namespace =  Buffer.from("_crazywallet-dev")
@@ -29,7 +30,7 @@ const userTree = async (userName:string) => {
     // Convert the key to a tupelo DID (ChainTree id)
     const did = await Tupelo.ecdsaPubkeyToDid(key.publicKey)
 
-    const community = await Community.getDefault()
+    const community = await getCommunity()
     let tip
     try {
         tip = await community.getTip(did)
@@ -151,7 +152,7 @@ const UsernameAvailable = ({userName}:{userName:string}) => {
         const secureKey = await EcdsaKey.passPhraseKey(Buffer.from(password), Buffer.from(userName))
         const secureKeyAddress = await Tupelo.ecdsaPubkeyToAddress(secureKey.publicKey)
         
-        const community = await Community.getDefault()
+        const community = await getCommunity()
         const tree = await ChainTree.newEmptyTree(community.blockservice, insecureKey)
 
         await community.playTransactions(tree, [

--- a/src/wallet/minttokendialog.tsx
+++ b/src/wallet/minttokendialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, TextField, CircularProgress, Button } from '@material-ui/core';
-import { ChainTree, Community, mintTokenTransaction } from 'tupelo-wasm-sdk'
+import { ChainTree, mintTokenTransaction } from 'tupelo-wasm-sdk'
+import { getCommunity } from '../community';
 
 /**
  * Mint token is really simple, just take a tokenName and ammount and create it.
@@ -16,7 +17,7 @@ export const MintTokenDialog = ({ open, onClose, tree, tokenName }: { tokenName:
             throw new Error("userTree is undefined")
         }
         setLoading(true)
-        const community = await Community.getDefault()
+        const community = await getCommunity()
         await community.playTransactions(tree, [mintTokenTransaction(tokenName, amount)])
         _onClose()
     }

--- a/src/wallet/receivetokendialog.tsx
+++ b/src/wallet/receivetokendialog.tsx
@@ -1,7 +1,8 @@
 import React, {useState} from 'react'
 import {  Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, TextField, CircularProgress, Button } from '@material-ui/core';
-import { ChainTree, Community, receiveTokenTransactionFromPayload } from 'tupelo-wasm-sdk'
+import { ChainTree, receiveTokenTransactionFromPayload } from 'tupelo-wasm-sdk'
 import { TokenPayload } from 'tupelo-messages/transactions/transactions_pb';
+import { getCommunity } from '../community';
 
 /**
  * Receive token is used on the *receiving* side of a token transaction. The sender does a send transaction and then 
@@ -21,7 +22,7 @@ export const ReceiveTokenDialog = ({open, onClose, tree}:{open:boolean, onClose:
         let tx = receiveTokenTransactionFromPayload(tokenPayload)
 
         setLoading(true)
-        const community = await Community.getDefault()
+        const community = await getCommunity()
         await community.playTransactions(tree, [tx])
         _onClose()
     }

--- a/src/wallet/sendtokendialog.tsx
+++ b/src/wallet/sendtokendialog.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react'
 import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, TextField, CircularProgress, Button } from '@material-ui/core';
 import TextareaAutosize from '@material-ui/core/TextareaAutosize';
-import { ChainTree, Community, sendTokenTransaction } from 'tupelo-wasm-sdk'
+import { ChainTree, sendTokenTransaction } from 'tupelo-wasm-sdk'
+import { getCommunity } from '../community';
 
 const uuidv4: () => string = require('uuid/v4');
 
@@ -25,7 +26,7 @@ export const SendTokenDialog = ({ open, onClose, tree, tokenName }: { tokenName:
         setLoading(true)
         //sendId must be unique to the receiving chaintree. Here we just use a globally unique uuid.
         const uuid = uuidv4()
-        const community = await Community.getDefault()
+        const community = await getCommunity()
         // const canonicalName = await tokenCanonicalName(tree, tokenName)
         console.log('tokenname: ', tokenName)
     


### PR DESCRIPTION
This makes it easier to swap out different communities by DRYing up the calls to a single call within the project.